### PR TITLE
fix: load dropped files into the active tool

### DIFF
--- a/src/components/tools/CompressTool.tsx
+++ b/src/components/tools/CompressTool.tsx
@@ -239,7 +239,7 @@ export default function CompressTool() {
   )
 
   return (
-    <NativeToolLayout title="Compress PDF" description="Reduce file size while maintaining quality. Everything stays on your device." actions={files.length > 0 && !showSuccess && <ActionButton />}>
+    <NativeToolLayout title="Compress PDF" description="Reduce file size while maintaining quality. Everything stays on your device." onFileDrop={(files) => handleFiles(files)} actions={files.length > 0 && !showSuccess && <ActionButton />}>
       <input type="file" multiple accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files && handleFiles(e.target.files)} />
       
       {files.length === 0 ? (

--- a/src/components/tools/ExtractImagesTool.tsx
+++ b/src/components/tools/ExtractImagesTool.tsx
@@ -138,7 +138,7 @@ export default function ExtractImagesTool() {
   )
 
   return (
-    <NativeToolLayout title="Extract Images" description="Find and save all original images embedded inside the PDF." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Extract Images" description="Find and save all original images embedded inside the PDF." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       {!pdfData ? (
         <div onClick={() => !isProcessing && fileInputRef.current?.click()} className="border-4 border-dashed border-gray-100 dark:border-zinc-900 rounded-[2.5rem] p-12 text-center hover:bg-rose-50 dark:hover:bg-rose-900/10 transition-all cursor-pointer group">

--- a/src/components/tools/GrayscaleTool.tsx
+++ b/src/components/tools/GrayscaleTool.tsx
@@ -124,7 +124,7 @@ export default function GrayscaleTool() {
   )
 
   return (
-    <NativeToolLayout title="PDF to Grayscale" description="Remove colors from your PDF to save ink and storage." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="PDF to Grayscale" description="Remove colors from your PDF to save ink and storage." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       {!pdfData ? (
         <div onClick={() => !isProcessing && fileInputRef.current?.click()} className="border-4 border-dashed border-gray-100 dark:border-zinc-900 rounded-[2.5rem] p-12 text-center hover:bg-rose-50 dark:hover:bg-rose-900/10 transition-all cursor-pointer group">

--- a/src/components/tools/ImageToPdfTool.tsx
+++ b/src/components/tools/ImageToPdfTool.tsx
@@ -71,7 +71,7 @@ export default function ImageToPdfTool() {
   )
 
   return (
-    <NativeToolLayout title="Image to PDF" description="Convert photos and images into a professional PDF." actions={images.length > 0 && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Image to PDF" description="Convert photos and images into a professional PDF." onFileDrop={(files) => handleFiles(files)} actions={images.length > 0 && !downloadUrl && <ActionButton />}>
       <input type="file" multiple accept="image/*" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files && handleFiles(e.target.files)} />
       {images.length === 0 ? (
         <div onClick={() => fileInputRef.current?.click()} className="border-4 border-dashed border-gray-100 dark:border-zinc-900 rounded-[2.5rem] p-12 text-center hover:bg-rose-50 dark:hover:bg-rose-900/10 transition-all cursor-pointer group">

--- a/src/components/tools/MergeTool.tsx
+++ b/src/components/tools/MergeTool.tsx
@@ -269,11 +269,13 @@ export default function MergeTool() {
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     setIsDraggingGlobal(true)
   }
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     if (e.currentTarget && !e.currentTarget.contains(e.relatedTarget as Node)) {
       setIsDraggingGlobal(false)
     }
@@ -281,6 +283,7 @@ export default function MergeTool() {
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     setIsDraggingGlobal(false)
     if (e.dataTransfer.files) handleFiles(e.dataTransfer.files)
   }

--- a/src/components/tools/MetadataTool.tsx
+++ b/src/components/tools/MetadataTool.tsx
@@ -156,7 +156,7 @@ export default function MetadataTool() {
   )
 
   return (
-    <NativeToolLayout title="Metadata Editor" description="Edit or wipe document properties for better privacy." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButtons />}>
+    <NativeToolLayout title="Metadata Editor" description="Edit or wipe document properties for better privacy." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButtons />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       {!pdfData ? (
         <div onClick={() => !isProcessing && fileInputRef.current?.click()} className="border-4 border-dashed border-gray-100 dark:border-zinc-900 rounded-[2.5rem] p-12 text-center hover:bg-rose-50 dark:hover:bg-rose-900/10 transition-all cursor-pointer group">

--- a/src/components/tools/PageNumberTool.tsx
+++ b/src/components/tools/PageNumberTool.tsx
@@ -104,7 +104,7 @@ export default function PageNumberTool() {
   }
 
   return (
-    <NativeToolLayout title="Page Numbers" description="Add custom numbering to your PDF automatically." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Page Numbers" description="Add custom numbering to your PDF automatically." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       
       {!pdfData ? (

--- a/src/components/tools/PdfToImageTool.tsx
+++ b/src/components/tools/PdfToImageTool.tsx
@@ -102,7 +102,7 @@ export default function PdfToImageTool() {
   )
 
   return (
-    <NativeToolLayout title="PDF to Image" description="Convert document pages into high-quality images." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="PDF to Image" description="Convert document pages into high-quality images." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       {!pdfData ? (
         <button 

--- a/src/components/tools/PdfToTextTool.tsx
+++ b/src/components/tools/PdfToTextTool.tsx
@@ -111,7 +111,7 @@ export default function PdfToTextTool() {
   )
 
   return (
-    <NativeToolLayout title="PDF to Text" description="Extract text using fast scan or deep local OCR." actions={pdfData && !pdfData.isLocked && !extractedText && <ActionButton />}>
+    <NativeToolLayout title="PDF to Text" description="Extract text using fast scan or deep local OCR." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !extractedText && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       {!pdfData ? (
         <div onClick={() => !isProcessing && fileInputRef.current?.click()} className="border-4 border-dashed border-gray-100 dark:border-zinc-900 rounded-[2.5rem] p-12 text-center hover:bg-rose-50 dark:hover:bg-rose-900/10 transition-all cursor-pointer group">

--- a/src/components/tools/ProtectTool.tsx
+++ b/src/components/tools/ProtectTool.tsx
@@ -100,7 +100,7 @@ export default function ProtectTool() {
   )
 
   return (
-    <NativeToolLayout title="Protect PDF" description="Add strong encryption to your documents. Processed locally." actions={pdfData && !pdfData.isLocked && !objectUrl && <ActionButton />}>
+    <NativeToolLayout title="Protect PDF" description="Add strong encryption to your documents. Processed locally." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !objectUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={handleFileSelect} />
       {!pdfData ? (
         <button 

--- a/src/components/tools/RearrangeTool.tsx
+++ b/src/components/tools/RearrangeTool.tsx
@@ -126,7 +126,7 @@ export default function RearrangeTool() {
   )
 
   return (
-    <NativeToolLayout title="Rearrange PDF" description="Drag and drop to reorder pages visually." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Rearrange PDF" description="Drag and drop to reorder pages visually." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       
       {!pdfData ? (

--- a/src/components/tools/RepairTool.tsx
+++ b/src/components/tools/RepairTool.tsx
@@ -63,7 +63,7 @@ export default function RepairTool() {
   )
 
   return (
-    <NativeToolLayout title="Repair PDF" description="Fix corrupted or unreadable PDF files by rebuilding structure." actions={originalFile && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Repair PDF" description="Fix corrupted or unreadable PDF files by rebuilding structure." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={originalFile && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       
       {!originalFile ? (

--- a/src/components/tools/RotateTool.tsx
+++ b/src/components/tools/RotateTool.tsx
@@ -99,7 +99,7 @@ export default function RotateTool() {
   )
 
   return (
-    <NativeToolLayout title="Rotate PDF" description="Tap individual pages to rotate 90 degrees." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Rotate PDF" description="Tap individual pages to rotate 90 degrees." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       
       {!pdfData ? (

--- a/src/components/tools/SignatureTool.tsx
+++ b/src/components/tools/SignatureTool.tsx
@@ -78,7 +78,7 @@ export default function SignatureTool() {
   )
 
   return (
-    <NativeToolLayout title="Signature" description="Sign any PDF by dragging your signature image." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Signature" description="Sign any PDF by dragging your signature image." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       <input type="file" accept="image/*" className="hidden" ref={signatureInputRef} onChange={(e) => { const file = e.target.files?.[0]; if (file) { setSignatureFile(file); setSignatureImg(URL.createObjectURL(file)) } }} />
       {!pdfData ? (

--- a/src/components/tools/SplitTool.tsx
+++ b/src/components/tools/SplitTool.tsx
@@ -176,6 +176,7 @@ export default function SplitTool() {
     <NativeToolLayout
       title="Split PDF"
       description="Select pages visually or by range to extract them. Everything stays on your device."
+      onFileDrop={(files) => files[0] && handleFile(files[0])}
       actions={pdfData && !pdfData.isLocked && !objectUrl && <ActionButton />}
     >
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={handleFileSelect} />

--- a/src/components/tools/UnlockTool.tsx
+++ b/src/components/tools/UnlockTool.tsx
@@ -72,7 +72,7 @@ export default function UnlockTool() {
   )
 
   return (
-    <NativeToolLayout title="Unlock PDF" description="Remove passwords and restrictions permanently. Processed locally." actions={pdfData && !objectUrl && <ActionButton />}>
+    <NativeToolLayout title="Unlock PDF" description="Remove passwords and restrictions permanently. Processed locally." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !objectUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={handleFileSelect} />
       {!pdfData ? (
         <button 

--- a/src/components/tools/WatermarkTool.tsx
+++ b/src/components/tools/WatermarkTool.tsx
@@ -109,7 +109,7 @@ export default function WatermarkTool() {
   )
 
   return (
-    <NativeToolLayout title="Watermark" description="Add secure text overlays to your documents locally." actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
+    <NativeToolLayout title="Watermark" description="Add secure text overlays to your documents locally." onFileDrop={(files) => files[0] && handleFile(files[0])} actions={pdfData && !pdfData.isLocked && !downloadUrl && <ActionButton />}>
       <input type="file" accept=".pdf" className="hidden" ref={fileInputRef} onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])} />
       
       {!pdfData ? (

--- a/src/components/tools/shared/NativeToolLayout.tsx
+++ b/src/components/tools/shared/NativeToolLayout.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { ArrowLeft } from 'lucide-react'
+import React, { useState } from 'react'
+import { ArrowLeft, Upload } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Capacitor } from '@capacitor/core'
 import ToolHeader from './ToolHeader'
@@ -10,16 +10,37 @@ interface NativeToolLayoutProps {
   children: React.ReactNode
   actions?: React.ReactNode
   onBack?: () => void
+  onFileDrop?: (files: FileList) => void
 }
 
-export const NativeToolLayout = ({ 
-  title, 
-  description, 
-  children, 
+export const NativeToolLayout = ({
+  title,
+  description,
+  children,
   actions,
-  onBack 
+  onBack,
+  onFileDrop
 }: NativeToolLayoutProps) => {
   const navigate = useNavigate()
+  const [isDragging, setIsDragging] = useState(false)
+
+  const dropHandlers = onFileDrop ? {
+    onDragOver: (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!isDragging) setIsDragging(true)
+    },
+    onDragLeave: (e: React.DragEvent) => {
+      e.preventDefault()
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) setIsDragging(false)
+    },
+    onDrop: (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging(false)
+      if (e.dataTransfer.files?.length) onFileDrop(e.dataTransfer.files)
+    },
+  } : {}
   
   // Determine if we should show the native-style header
   // It should only show if we are in Android/APK mode
@@ -31,7 +52,17 @@ export const NativeToolLayout = ({
   const showNativeHeader = isAndroidView
 
   return (
-    <div className="flex flex-col min-h-screen bg-[#FAFAFA] dark:bg-black transition-colors">
+    <div className="flex flex-col min-h-screen bg-[#FAFAFA] dark:bg-black transition-colors" {...dropHandlers}>
+      {/* Drag-to-load overlay */}
+      {onFileDrop && isDragging && (
+        <div className="fixed inset-0 z-[120] bg-rose-500/10 backdrop-blur-sm flex items-center justify-center pointer-events-none p-6">
+          <div className="bg-white dark:bg-zinc-900 px-10 py-8 rounded-[2rem] shadow-2xl border-4 border-dashed border-rose-500 flex flex-col items-center gap-3 animate-in zoom-in duration-200">
+            <Upload size={48} className="text-rose-500" />
+            <p className="font-black uppercase tracking-widest text-rose-500 text-sm text-center">Drop to load into {title}</p>
+          </div>
+        </div>
+      )}
+
       {/* Ultra-Compact Native AppBar - Only shown in Android/Native mode on mobile */}
       {showNativeHeader && (
         <header className="px-4 pt-safe pb-1 flex items-center justify-between sticky top-0 z-30 bg-[#FAFAFA]/95 dark:bg-black/95 backdrop-blur-xl md:hidden border-b border-gray-100 dark:border-white/5">


### PR DESCRIPTION
Fixes #55.

A drop on an open tool now loads the file into that tool. The global preview / Quick-Drop stays for the home view only.

### Changes

- `NativeToolLayout`: a new optional `onFileDrop` prop turns the tool screen into a drop target. The handlers call `preventDefault` and `stopPropagation` (so the global drop handler no longer fires) and show a drag overlay.
- Every tool forwards the dropped file to its own `handleFile` / `handleFiles`.
- `MergeTool`: added `stopPropagation()` to its existing dropzone, which removes the duplicate preview.
- The global `handleGlobalDrop` is unchanged and still handles the home view.


### Testing

- Dropping a PDF into `/#/split`, `/#/merge`, and `/#/image-to-pdf` loads it into that tool; the home view still shows the picker; Merge no longer opens a second preview.
- `npm run dev` and `tsc --noEmit` pass. No new dependencies. The Android path is unaffected.

### Screenshots
**Before:** 
<img width="800" height="389" alt="ezgif-65e1c9f1f0c0be15" src="https://github.com/user-attachments/assets/14e0c578-b6e4-47f6-8329-d09198f1fe94" />

**After**
<img width="800" height="389" alt="ezgif-3e80fa521bde7ca4" src="https://github.com/user-attachments/assets/072b305c-bd67-4c41-b07d-75c51ecb83bc" />

