### PR TITLE
fix: keep tool-panel controls inside their card on narrow widths

### DIFF
--- a/src/components/tools/MergeTool.tsx
+++ b/src/components/tools/MergeTool.tsx
@@ -90,7 +90,7 @@ function SortableItem({ id, file, onRemove, onRotate, onUnlock }: { id: string, 
               placeholder="Password" 
               value={localPass}
               onChange={(e) => setLocalPass(e.target.value)}
-              className="flex-1 bg-gray-50 dark:bg-black border border-gray-100 dark:border-zinc-800 rounded-lg px-2 py-1 text-[10px] font-bold outline-none focus:border-rose-500 text-gray-900 dark:text-white"
+              className="flex-1 min-w-0 bg-gray-50 dark:bg-black border border-gray-100 dark:border-zinc-800 rounded-lg px-2 py-1 text-[10px] font-bold outline-none focus:border-rose-500 text-gray-900 dark:text-white"
             />
             <button 
               onClick={handleUnlockClick}

--- a/src/components/tools/SplitTool.tsx
+++ b/src/components/tools/SplitTool.tsx
@@ -298,14 +298,14 @@ export default function SplitTool() {
                     <div>
                       <label className="block text-[10px] font-black uppercase tracking-widest text-gray-400 mb-3">Range Selection</label>
                       <div className="flex gap-2">
-                        <input type="text" value={rangeInput} onChange={(e) => setRangeInput(e.target.value)} placeholder="e.g. 1, 3-5" className="flex-1 bg-gray-50 dark:bg-black rounded-xl px-4 py-3 border border-transparent focus:border-rose-500 outline-none font-bold text-sm dark:text-white" />
+                        <input type="text" value={rangeInput} onChange={(e) => setRangeInput(e.target.value)} placeholder="e.g. 1, 3-5" className="flex-1 min-w-0 bg-gray-50 dark:bg-black rounded-xl px-4 py-3 border border-transparent focus:border-rose-500 outline-none font-bold text-sm dark:text-white" />
                         <button onClick={() => parseRange(rangeInput)} className="px-4 bg-rose-500 text-white rounded-xl font-black text-[10px] uppercase active:scale-95 transition-transform">Apply</button>
                       </div>
                       <p className="text-[8px] text-gray-400 mt-2 px-1">Use commas for separate pages and dashes for ranges.</p>
                     </div>
                   </div>
                   <div className="pt-6 border-t border-gray-100 dark:border-white/5">
-                    <div className="flex justify-between items-end mb-4 px-1">
+                    <div className="flex justify-between items-center mb-4 px-1">
                       <span className="text-[10px] font-black text-gray-400 uppercase tracking-[0.2em]">Selected</span>
                       <span className="text-xl font-black text-rose-500">{selectedPages.size} <span className="text-[10px] text-gray-400 font-bold uppercase tracking-widest">Pages</span></span>
                     </div>

--- a/src/components/tools/shared/SuccessState.tsx
+++ b/src/components/tools/shared/SuccessState.tsx
@@ -114,17 +114,17 @@ export default function SuccessState({ message, downloadUrl, fileName, onStartOv
           {showPreview && (
             <button 
               onClick={handlePreview}
-              className="flex-1 bg-white dark:bg-zinc-900 text-gray-900 dark:text-white border border-gray-200 dark:border-zinc-800 p-4 rounded-2xl md:rounded-3xl shadow-sm font-black text-sm md:text-xl tracking-tight transition-all hover:bg-gray-50 active:scale-95 flex items-center justify-center gap-2"
+              className="flex-1 min-w-0 bg-white dark:bg-zinc-900 text-gray-900 dark:text-white border border-gray-200 dark:border-zinc-800 px-3 py-4 rounded-2xl md:rounded-3xl shadow-sm font-black text-sm tracking-tight transition-all hover:bg-gray-50 active:scale-95 flex items-center justify-center gap-2"
             >
-              <Eye size={20} /> Preview
+              <Eye size={18} /> Preview
             </button>
           )}
           
           <button 
             onClick={handleShare}
-            className="flex-1 bg-rose-50 dark:bg-rose-900/20 text-rose-500 border border-rose-100 dark:border-rose-900/30 p-4 rounded-2xl md:rounded-3xl shadow-sm font-black text-sm md:text-xl tracking-tight transition-all active:scale-95 flex items-center justify-center gap-2"
+            className="flex-1 min-w-0 bg-rose-50 dark:bg-rose-900/20 text-rose-500 border border-rose-100 dark:border-rose-900/30 px-3 py-4 rounded-2xl md:rounded-3xl shadow-sm font-black text-sm tracking-tight transition-all active:scale-95 flex items-center justify-center gap-2"
           >
-            <Share2 size={20} /> Share
+            <Share2 size={18} /> Share
           </button>
         </div>
         


### PR DESCRIPTION
Fixes #56.

### Changes

- `min-w-0` on the Split range input and the Merge password input so they shrink instead of pushing the adjacent button outside the card.
- Split selected-count row: `items-end` changed to `items-center`.
- Shared `SuccessState`: the Preview and Share buttons get `min-w-0`, drop `md:text-xl` (they stay `text-sm`), and use a smaller icon and padding, so they no longer overflow the narrow sidebar. The Download button is left as the primary action.

### Testing

- At 375px and 1440px: no row overflow, Preview and Share are equal width and flush with the card, the Apply button stays inside the card, and the selected-count row is aligned.
- `tsc --noEmit` passes. No new dependencies.

### Screenshots
**Before:**
<img width="800" height="389" alt="ezgif-61ab760eaf34196e" src="https://github.com/user-attachments/assets/16cf0856-0851-41ad-8f5c-35affbba306b" />

**After:**
<img width="1250" height="723" alt="image" src="https://github.com/user-attachments/assets/4459028c-da48-4311-8645-39bd27145698" />
